### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,5 @@ newman run postman/collection.json \
   -e postman/environment.json \
   --reporters cli,junit \
   --reporter-junit-export results.xml
+```
 You’ll see test output in your terminal, and a results.xml file for JUnit-format logs.


### PR DESCRIPTION
## Summary
- add closing triple backtick after Newman command example
- clean up trailing container prompt

## Testing
- `npm test` *(fails: Missing script)*