### PR TITLE
Configure Codex to run Newman tests

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,5 @@
+setup: |
+  npm install
+  npm install -g newman newman-reporter-htmlextra
+
+test: npm test

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "newman-reporter-htmlextra": "^1.23.1"
+  },
+  "scripts": {
+    "test": "newman run postman/collection.json -e postman/environment.testnet.json --reporters cli,junit,htmlextra --reporter-junit-export results.xml --reporter-htmlextra-export newman-report.html"
   }
 }


### PR DESCRIPTION
## Summary
- set up Codex so that Newman tests run before creating PRs
- add a convenient `npm test` script for executing the Postman collection

## Testing
- `npm test` *(fails: `newman` not found)*